### PR TITLE
Add size/speed-optimized FreeBASIC build scripts and batch optimizer

### DIFF
--- a/COMPILE.BAT
+++ b/COMPILE.BAT
@@ -1,1 +1,18 @@
-d:fbc -g -fpmode fast -fpu sse -w all "c64dv~21.bas" -map c64dvd-glsl.map -Wc -mcmodel=small -Wc -msse2avx -Wc -Ofast -Wc -ffp-contract=fast -Wc -foptimize-sibling-calls -Wc -foptimize-strlen -Wc -fno-inline -Wc -save-temps -Wc -O3 -Wc -msse2avx
+@echo off
+setlocal
+
+set SRC_FILE=%~1
+if "%SRC_FILE%"=="" set SRC_FILE=c64dv~21.bas
+
+set OUT_FILE=%~2
+if "%OUT_FILE%"=="" set OUT_FILE=%~n1
+if "%OUT_FILE%"=="" set OUT_FILE=c64dvd-glsl
+
+set MAP_FILE=%OUT_FILE%.map
+
+d:\fbc -w all -fpmode fast -fpu sse -O 3 -gen gcc -s "%SRC_FILE%" -x "%OUT_FILE%" -map "%MAP_FILE%" ^
+-Wc -Ofast -Wc -ffast-math -Wc -ffp-contract=fast -Wc -fomit-frame-pointer ^
+-Wc -foptimize-sibling-calls -Wc -fmerge-all-constants -Wc -fdata-sections -Wc -ffunction-sections ^
+-Wl,--gc-sections -Wc -msse2avx
+
+endlocal

--- a/README.md
+++ b/README.md
@@ -1674,3 +1674,14 @@ https://michaelcmartin.github.io/Ophis/book/book1.html
 # Ophis Github page:
 
 https://github.com/michaelcmartin/Ophis
+
+## Optimized FreeBASIC builds (size + speed)
+
+- Single-target optimized builds now use `compile_lnx.sh`, `compile_win.bat`, or `COMPILE.BAT` with aggressive optimization and stripping enabled by default.
+- To batch-build optimized binaries for all `.bas` sources, run:
+
+```bash
+./tools/optimize_all_freebasic.sh
+```
+
+Output binaries are written under `build/optimized/` preserving the source tree layout.

--- a/compile_lnx.sh
+++ b/compile_lnx.sh
@@ -1,1 +1,28 @@
-fbc -g -fpmode fast -fpu sse -w all "c64dvd-glsl.bas" -map c64dvd-glsl.map -Wc -mcmodel=small -Wc -msse2avx -Wc -Ofast -Wc -ffp-contract=fast -Wc -foptimize-sibling-calls -Wc -foptimize-strlen -Wc -fno-inline -Wc -save-temps -Wc -O3 -Wc -msse2avx
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Optimized FreeBASIC build profile (balanced for size + speed)
+SRC_FILE="${1:-c64dvd-glsl.bas}"
+OUT_FILE="${2:-${SRC_FILE%.bas}}"
+MAP_FILE="${OUT_FILE}.map"
+
+fbc \
+  -w all \
+  -fpmode fast \
+  -fpu sse \
+  -O 3 \
+  -gen gcc \
+  -s \
+  -map "${MAP_FILE}" \
+  "${SRC_FILE}" \
+  -x "${OUT_FILE}" \
+  -Wc -Ofast \
+  -Wc -ffast-math \
+  -Wc -ffp-contract=fast \
+  -Wc -fomit-frame-pointer \
+  -Wc -foptimize-sibling-calls \
+  -Wc -fmerge-all-constants \
+  -Wc -fdata-sections \
+  -Wc -ffunction-sections \
+  -Wl,--gc-sections \
+  -Wc -msse2avx

--- a/compile_win.bat
+++ b/compile_win.bat
@@ -1,1 +1,18 @@
-c:fbc -g -fpmode fast -fpu sse -w all "c64dvd-glsl.bas" -map c64dvd-glsl.map -Wc -mcmodel=small -Wc -msse2avx -Wc -Ofast -Wc -ffp-contract=fast -Wc -foptimize-sibling-calls -Wc -foptimize-strlen -Wc -fno-inline -Wc -save-temps -Wc -O3 -Wc -msse2avx
+@echo off
+setlocal
+
+set SRC_FILE=%~1
+if "%SRC_FILE%"=="" set SRC_FILE=c64dvd-glsl.bas
+
+set OUT_FILE=%~2
+if "%OUT_FILE%"=="" set OUT_FILE=%~n1
+if "%OUT_FILE%"=="" set OUT_FILE=c64dvd-glsl
+
+set MAP_FILE=%OUT_FILE%.map
+
+c:\fbc -w all -fpmode fast -fpu sse -O 3 -gen gcc -s "%SRC_FILE%" -x "%OUT_FILE%" -map "%MAP_FILE%" ^
+-Wc -Ofast -Wc -ffast-math -Wc -ffp-contract=fast -Wc -fomit-frame-pointer ^
+-Wc -foptimize-sibling-calls -Wc -fmerge-all-constants -Wc -fdata-sections -Wc -ffunction-sections ^
+-Wl,--gc-sections -Wc -msse2avx
+
+endlocal

--- a/tools/optimize_all_freebasic.sh
+++ b/tools/optimize_all_freebasic.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${1:-${ROOT_DIR}/build/optimized}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+while IFS= read -r src; do
+  rel="${src#${ROOT_DIR}/}"
+  out_dir="${OUTPUT_DIR}/$(dirname "${rel}")"
+  out_name="$(basename "${src}" .bas)"
+
+  mkdir -p "${out_dir}"
+
+  echo "Optimizing ${rel} -> ${out_dir}/${out_name}"
+  fbc \
+    -w all \
+    -fpmode fast \
+    -fpu sse \
+    -O 3 \
+    -gen gcc \
+    -s \
+    "${src}" \
+    -x "${out_dir}/${out_name}" \
+    -Wc -Ofast \
+    -Wc -ffast-math \
+    -Wc -ffp-contract=fast \
+    -Wc -fomit-frame-pointer \
+    -Wc -foptimize-sibling-calls \
+    -Wc -fmerge-all-constants \
+    -Wc -fdata-sections \
+    -Wc -ffunction-sections \
+    -Wl,--gc-sections \
+    -Wc -msse2avx || true
+
+done < <(find "${ROOT_DIR}" -type f -name '*.bas' -not -path '*/build/*' | sort)


### PR DESCRIPTION
### Motivation
- Provide a reproducible, repo-wide way to build FreeBASIC targets with aggressive size and speed optimizations without manually editing many source files.

### Description
- Added `compile_lnx.sh` which is parameterized for `SRC_FILE`/`OUT_FILE` and applies aggressive compiler/linker flags (`-O3`, `-Ofast`, `-ffast-math`, `-fomit-frame-pointer`, section GC, stripped symbols) for smaller/faster binaries.
- Updated `compile_win.bat` and `COMPILE.BAT` to accept optional source/output arguments and to mirror the same optimization profile for Windows builds.
- Added `tools/optimize_all_freebasic.sh` to walk the tree and batch-build optimized binaries for every `*.bas` into `build/optimized/` while preserving directory layout.
- Documented the new workflow in `README.md` and ensured scripts are executable and syntax-checked.

### Testing
- Ran `bash -n compile_lnx.sh` which returned no syntax errors indicating the script is valid.
- Ran `bash -n tools/optimize_all_freebasic.sh` which returned no syntax errors indicating the batch script is valid.
- Attempted to run `./compile_lnx.sh c64dvd-glsl.bas /tmp/c64dvd-glsl-opt` but the run failed with `fbc: command not found` in this environment, so no optimized binaries could be produced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71890f968832ca62701b3cd0d61f8)