### PR TITLE
Optimize pixel helper macros in qb64.bi

### DIFF
--- a/qb64.bi
+++ b/qb64.bi
@@ -128,8 +128,8 @@ type _FBARRAY
 end type
 type as _FBARRAY FBARRAY
 
-#define BYTES_PER_PIXEL(d)		(((d) + 7) / 8)
-#define BPP_MASK(b)				cast((int32),((1ll shl ((b) shl 3)) - 1))
+#define BYTES_PER_PIXEL(d)		(((d) + 7) shr 3)
+#define BPP_MASK(b)				cast((int32), iif((b) >= 4, &HFFFFFFFFu, ((1u shl ((b) shl 3)) - 1u)))
 
 #define DEFAULT_COLOR_1			&H80000000
 #define DEFAULT_COLOR_2			&H40000000


### PR DESCRIPTION
### Motivation
- Reduce cost and potential issues in pixel-size and mask calculations by replacing division and oversized shifts with safer bit operations.
- Avoid undefined or expensive large-shift behavior when computing masks for 32-bit/4+ byte pixel formats.

### Description
- Replace `BYTES_PER_PIXEL` division with a right-shift by 3 using `(((d) + 7) shr 3)` to compute bytes per pixel more efficiently.
- Harden `BPP_MASK` to return `0xFFFFFFFF` for `b >= 4` and otherwise compute the mask with unsigned shifts and subtraction using `iif((b) >= 4, &HFFFFFFFFu, ((1u shl ((b) shl 3)) - 1u))`, and cast the result to `int32`.
- Limit the change to the header-like `qb64.bi` file so the optimization is isolated to the pixel helper macros.

### Testing
- Ran `rg "BPP_MASK|BYTES_PER_PIXEL" qb64.bi qb64.bas` and confirmed the updated macros exist in `qb64.bi` and are not duplicated elsewhere (success).
- Inspected the modified lines with `nl -ba qb64.bi | sed -n '120,145p'` to verify the exact replacement (success).
- Reviewed the repository diff for `qb64.bi` with `git diff -- qb64.bi` to ensure only the intended macro lines changed (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a721f8a834832ca1d4a0a13ee31d4b)