### PR TITLE
Improve win32.bi portability for Unix-like and FreeDOS targets

### DIFF
--- a/win32.bi
+++ b/win32.bi
@@ -20,13 +20,28 @@
 #define _CRTALLOC(x)        allocate(x)
 #define DECLSPEC_ALIGN(x)   x
 
+#if defined(__FB_WIN32__) or defined(__FB_WIN64__)
+    #define WIN32BI_HOST_WINDOWS 1
+#else
+    #define WIN32BI_HOST_WINDOWS 0
+#endif
+
 /' Basic Defines: '/
-#define NTAPI    stdcall
-#define WINAPI   stdcall
-#define APIENTRY stdcall
-#define CALLBACK stdcall
+#if WIN32BI_HOST_WINDOWS
+    #define WIN32BI_CALLCONV stdcall
+#else
+    #define WIN32BI_CALLCONV cdecl
+#endif
+
+#define NTAPI    WIN32BI_CALLCONV
+#define WINAPI   WIN32BI_CALLCONV
+#define APIENTRY WIN32BI_CALLCONV
+#define CALLBACK WIN32BI_CALLCONV
 #ifndef FORCEINLINE
 #define FORCEINLINE __forceinline
+#endif
+#ifndef __forceinline
+#define __forceinline inline
 #endif
 #ifdef UNICODE
 #define __TEXT(x) L ## x
@@ -36,6 +51,14 @@
 #endif
 #define PATH_MAX 260
 #define MAX_PATH 260
+#define WIN32BI_PATH_SEP_WIN "\\"
+#define WIN32BI_PATH_SEP_UNIX "/"
+
+#if WIN32BI_HOST_WINDOWS
+    #define WIN32BI_PATH_SEP WIN32BI_PATH_SEP_WIN
+#else
+    #define WIN32BI_PATH_SEP WIN32BI_PATH_SEP_UNIX
+#endif
 
 #define _WINDEF_
 #define _MINWINDEF_
@@ -245,6 +268,18 @@ type as HANDLE              HGLRC
 type as HANDLE              HMENU
 type as HANDLE ptr          PHANDLE
 type as HANDLE ptr          LPHANDLE
+
+#ifndef INVALID_HANDLE_VALUE
+const INVALID_HANDLE_VALUE = cast(HANDLE, -1)
+#endif
+
+#ifndef WAIT_OBJECT_0
+const WAIT_OBJECT_0 = 0
+#endif
+
+#ifndef WAIT_TIMEOUT
+const WAIT_TIMEOUT = 258
+#endif
 
 #define DECLARE_HANDLE(name) type name##__ _
  as integer unused _


### PR DESCRIPTION
### Motivation
- Reduce friction when porting Win32-oriented FreeBASIC sources to Unix-like systems and FreeDOS by providing minimal compatibility shims and platform detection in `win32.bi`.
- Make calling-convention, inlining and path-separator differences transparent so downstream source files require fewer manual edits.

### Description
- Added host detection macro `WIN32BI_HOST_WINDOWS` to distinguish Windows FreeBASIC targets from others and introduced `WIN32BI_CALLCONV` to map `stdcall` on Windows and `cdecl` elsewhere, then reused it for `NTAPI`, `WINAPI`, `APIENTRY`, and `CALLBACK`.
- Added a fallback `__forceinline` definition for toolchains that lack `__forceinline` and preserved existing `FORCEINLINE` behavior.
- Introduced platform path-separator macros `WIN32BI_PATH_SEP_WIN`, `WIN32BI_PATH_SEP_UNIX`, and `WIN32BI_PATH_SEP` to centralize path differences.
- Added guarded compatibility constants `INVALID_HANDLE_VALUE`, `WAIT_OBJECT_0`, and `WAIT_TIMEOUT` to provide common Win32 idioms on non-Windows targets without redefining them when already present.

### Testing
- Performed static inspections of the modified header using `rg`, `sed`, and `nl` to verify the new macros and constants are present and correctly placed in `win32.bi`.
- Verified the patch application succeeded and the working tree shows the updated `win32.bi` file via repository status checks.
- Checked for a local FreeBASIC compiler with `command -v fbc`, which returned no result in this environment, so no compile-time validation was possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72a49315c832cb11bf95089b1691c)