### PR TITLE
Add GLSL version constants, sampler fixes and texture helpers to GLSL emulator

### DIFF
--- a/glslstyle.bas
+++ b/glslstyle.bas
@@ -3384,3 +3384,20 @@ Type p_state
      bk as integer
 End Type
 '/
+
+' GLSL version dispatcher for portability across target platforms.
+' 4.60 requests are mapped to the most capable local emulator path.
+def SYSTEM_BUS_T.EXEC_GLSL_VERSION(glslVersion as longint = GLSL_VERSION_LATEST)
+  select case glslVersion
+    case is < GLSL_VERSION_090
+      EXEC_GLSL_40()
+    case is < GLSL_VERSION_120
+      EXEC_GLSL_90()
+    case else
+      EXEC_GLSL_120()
+  end select
+end def
+
+def SYSTEM_BUS_T.EXEC_GLSL_LATEST()
+  EXEC_GLSL_VERSION(GLSL_VERSION_LATEST)
+end def

--- a/glslstyle.bi
+++ b/glslstyle.bi
@@ -59,6 +59,14 @@ FreeBASIC:
 #define DEG2RAD M_PI/180.0
 #define RAD2DEG 180.0/M_PI
 
+' GLSL profile metadata (mirrors modern desktop versions)
+const GLSL_VERSION_040 = 40
+const GLSL_VERSION_090 = 90
+const GLSL_VERSION_120 = 120
+const GLSL_VERSION_330 = 330
+const GLSL_VERSION_460 = 460
+const GLSL_VERSION_LATEST = GLSL_VERSION_460
+
 #define dot2(a) k_dot((a),(a))
 'function dot2(v as vec3) as float
 '  return dot(v,v)
@@ -1382,7 +1390,7 @@ Type sampler2D
      declare Sub Fill(color as ULong)
      declare Sub FastFillBox(x1 as Integer, y1 as Integer, x2 as Integer, y2 as Integer, xcolor as ULong)
      declare Function CreateSampler2D() As sampler2D
-     declare Function Sample(x as float, y as float) as float
+     declare Function Sample(x as float, y as float) as ULong
 End Type
 
 Sub sampler2D.Lock()
@@ -1394,12 +1402,14 @@ Sub sampler2D.Unlock()
 End Sub
 
 Sub sampler2D.WritePixel(x as Integer, y as Integer, xcolor as ULong)
-    Dim As ULong Ptr pixel = PixelData + y * Pitch + x * BytesPerPixel
+    Dim As UByte Ptr base = cast(UByte Ptr, PixelData)
+    Dim As ULong Ptr pixel = cast(ULong Ptr, base + y * Pitch + x * BytesPerPixel)
     *pixel = xcolor
 End Sub
 
 Function sampler2D.ReadPixel(x as Integer, y as Integer) as ULong
-    Dim As ULong Ptr pixel = PixelData + y * Pitch + x * BytesPerPixel
+    Dim As UByte Ptr base = cast(UByte Ptr, PixelData)
+    Dim As ULong Ptr pixel = cast(ULong Ptr, base + y * Pitch + x * BytesPerPixel)
     Return *pixel
 End Function
 
@@ -1436,12 +1446,45 @@ End Sub
 Function sampler2D.CreateSampler2D() As sampler2D
     Dim As sampler2D result
     ScreenInfo result.Width, result.Height, , result.BytesPerPixel, result.Pitch
-    result.PixelData = ImageCreate(Width, Height, , BytesPerPixel)
+    result.PixelData = ImageCreate(result.Width, result.Height, , result.BytesPerPixel)
     Return result
 End Function
 
-Function sampler2D.Sample(x as float, y as float) as float
-    Dim As Integer ix = Int(x * Width)
-    Dim As Integer iy = Int(y * Height)
+Function sampler2D.Sample(x as float, y as float) as ULong
+    Dim As Integer ix = Int(x * (Width - 1))
+    Dim As Integer iy = Int(y * (Height - 1))
+    if ix < 0 then ix = 0
+    if iy < 0 then iy = 0
+    if ix >= Width then ix = Width - 1
+    if iy >= Height then iy = Height - 1
     Return ReadPixel(ix, iy)
 End Function
+
+' GLSL 3.30+/4.60 style texture helpers
+function texture(byref image as sampler2D, byref uv as vector2) as vector4
+    dim as ulong c = image.Sample(uv.x, uv.y)
+    return vector4( _
+        cast(float, (c shr 16) and 255) / 255.0, _
+        cast(float, (c shr 8) and 255) / 255.0, _
+        cast(float, c and 255) / 255.0, _
+        cast(float, (c shr 24) and 255) / 255.0)
+end function
+
+function texture(byref image as sampler2D, x as float, y as float) as vector4
+    return texture(image, vector2(x, y))
+end function
+
+function texelFetch(byref image as sampler2D, byref xy as vector2) as vector4
+    dim as integer ix = cint(xy.x)
+    dim as integer iy = cint(xy.y)
+    if ix < 0 then ix = 0
+    if iy < 0 then iy = 0
+    if ix >= image.Width then ix = image.Width - 1
+    if iy >= image.Height then iy = image.Height - 1
+    dim as ulong c = image.ReadPixel(ix, iy)
+    return vector4( _
+        cast(float, (c shr 16) and 255) / 255.0, _
+        cast(float, (c shr 8) and 255) / 255.0, _
+        cast(float, c and 255) / 255.0, _
+        cast(float, (c shr 24) and 255) / 255.0)
+end function


### PR DESCRIPTION
### Motivation
- Modernize the built-in GLSL emulator so shader code can target newer GLSL profiles symbolically while remaining portable to FreeDOS and Unix-like systems. 
- Fix cross-platform pointer arithmetic and sampling behavior in the `sampler2D` implementation to avoid byte-offset bugs on different ABIs. 
- Provide GLSL-style texture helpers so existing shaders using `texture`/`texelFetch` idioms can run without external libraries. 

### Description
- Added explicit GLSL version constants and `GLSL_VERSION_LATEST` to `glslstyle.bi` so callers can request a target profile by symbol. 
- Reworked `sampler2D` internals in `glslstyle.bi` to use byte-based pointer arithmetic for `WritePixel`/`ReadPixel`, fixed `CreateSampler2D()` to allocate with `result` dimensions, and changed `Sample()` to return `ULong` pixel data with bounds-safe clamping. 
- Implemented GLSL-style helpers in `glslstyle.bi`: `texture(image, uv)`, `texture(image, x, y)` and `texelFetch(image, xy)` that return normalized `vector4` color values. 
- Added a version-dispatch entrypoint in `glslstyle.bas`: `EXEC_GLSL_VERSION(glslVersion)` and `EXEC_GLSL_LATEST()` that map requested GLSL versions to the existing emulator implementations. 

### Testing
- Ran `git diff --check` which reported no whitespace or patch errors. 
- Inspected diffs and file contents (`git diff --stat` / file listings) to verify inserted declarations and functions were placed correctly. 
- Checked for FreeBASIC availability with `which fbc` and found the compiler is not present in this environment, so a full compile/runtime validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7324d95ac832ca58c0e29c2bc847f)