### PR TITLE
Add 16MB artifact size budget validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Project Manhattan is a next-generation MOS 6510-based CPU/GPU combo system on a 
 
 The system on a chip emulator is designed to work at all layers of abstraction(BIOS replacement to being used as an embedded application in a webpage). As such, the emulator must be self-contained and have a maximum file size limit of 16MB.
 
+## Size-budget check
+
+Use `tools/check_size_budget.sh <artifact> [max_mb]` to verify generated binaries stay within the 16MB default deployment limit.
+
 CPU - 4Ghz, 64-Bit, MOS 6510/VICE compatible, can address up to 1.797693134862316e+308 bytes of system memory.
 
 NOTE: System memory addresses can have any positive value in the range 4.940656458412465e-324 to 1.797693134862316e+308, 

--- a/tools/check_size_budget.sh
+++ b/tools/check_size_budget.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforce the Project Manhattan self-contained binary budget.
+# Usage:
+#   tools/check_size_budget.sh <file> [max_mb]
+# Examples:
+#   tools/check_size_budget.sh c64dvd-glsl.exe
+#   tools/check_size_budget.sh c64dvd-glsl.exe 16
+
+if [[ ${1:-} == "" ]]; then
+  echo "Usage: $0 <file> [max_mb]" >&2
+  exit 2
+fi
+
+artifact="$1"
+max_mb="${2:-16}"
+
+if [[ ! -f "$artifact" ]]; then
+  echo "ERROR: artifact not found: $artifact" >&2
+  exit 2
+fi
+
+size_bytes=$(wc -c < "$artifact")
+max_bytes=$((max_mb * 1024 * 1024))
+
+printf 'Artifact: %s\n' "$artifact"
+printf 'Size: %d bytes\n' "$size_bytes"
+printf 'Budget: %d MB (%d bytes)\n' "$max_mb" "$max_bytes"
+
+if (( size_bytes > max_bytes )); then
+  echo "FAIL: artifact exceeds size budget by $((size_bytes - max_bytes)) bytes" >&2
+  exit 1
+fi
+
+echo "PASS: artifact is within the size budget"


### PR DESCRIPTION
### Motivation
- Provide a simple, scriptable check to enforce the project's self-contained binary size constraint (16MB) so CI and developers can validate build artifacts.

### Description
- Add `tools/check_size_budget.sh`, a small POSIX-compatible script that verifies an artifact exists and fails with a non-zero exit code if its size exceeds a configurable MB budget (default 16MB), and document usage in `README.md` under a new `## Size-budget check` section using `tools/check_size_budget.sh <artifact> [max_mb]`.

### Testing
- Ran `tools/check_size_budget.sh c64dvd-glsl.exe` which reported PASS and exited zero because `c64dvd-glsl.exe` (869712 bytes) is within the 16MB budget.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7355f8990832cbfd7550c94f16cff)