### PR TITLE
Fix TString buffer resize safety and empty-string suffix check

### DIFF
--- a/src/shared/tstring.bas
+++ b/src/shared/tstring.bas
@@ -28,7 +28,7 @@ sub TString.SetText(s as unsigned byte ptr)
     this.Len=strlen(s)
     this.ResizeBuffer(this.Len)
 
-    dim i as integer
+    dim i as integer=0
     while s[i]<>0
         this.Buffer[i]=s[i]
         i+=1
@@ -39,9 +39,13 @@ end sub
 sub TString.ResizeBuffer(newlen as unsigned integer)
     var newBufferSize=newlen+(512-(newlen mod 512))
     if (this.Buffer=0 or this.BufferSize<newBufferSize) then
-        if (this.Buffer<>0) then MFree(this.Buffer)
+        var oldBuffer=this.Buffer
+        var oldBufferSize=this.BufferSize
         var b=MAlloc(newBufferSize)
-        if (this.Buffer<>0) then memcpy(b,this.Buffer,this.BufferSize)
+        if (oldBuffer<>0) then
+            memcpy(b,oldBuffer,min(oldBufferSize,newBufferSize))
+            MFree(oldBuffer)
+        end if
         this.Buffer=b
         this.BufferSize=newBufferSize
     end if
@@ -100,6 +104,7 @@ function TString.ContainsChar(b as unsigned byte) as integer
 end function
 
 function TString.EndsWithChar(b as unsigned byte) as integer
+    if this.Len=0 then return 0
     return this.Buffer[this.Len-1]=b
 end function
 


### PR DESCRIPTION
### Motivation

- Prevent undefined reads when copying input into `TString` by ensuring the copy index is initialized. 
- Eliminate a use-after-free and unsafe copy size in `TString.ResizeBuffer` and avoid out-of-bounds reads when checking suffixes of an empty string.

### Description

- Initialize the local index in `TString.SetText` (`dim i as integer=0`) to avoid reading from an uninitialized variable when copying bytes. 
- Change `TString.ResizeBuffer` to allocate a new buffer, copy from the old buffer into the new buffer using `min(oldBufferSize,newBufferSize)`, and then free the old buffer to avoid use-after-free and over-copying. 
- Add an empty-string guard in `TString.EndsWithChar` to return `0` when `this.Len=0` instead of dereferencing `this.Buffer[this.Len-1]`. 
- Modified file: `src/shared/tstring.bas`.

### Testing

- Confirmed the patch applied cleanly and reviewed the resulting diff for `src/shared/tstring.bas`. 
- Ran repository status and diff checks to validate the change was recorded in the tree. 
- Attempted to compile with `fbc` but the FreeBASIC compiler was not available in the environment, so no binary build/compile tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7379c3584832c86039abb15ace808)