### PR TITLE
Enforce 16MB self-contained budget in FreeBASIC emulator startup

### DIFF
--- a/main.bas
+++ b/main.bas
@@ -6,6 +6,37 @@
 
 dim as uinteger text_buffer = char_buffer
 
+const as ulongint MAX_SELF_CONTAINED_BUDGET_BYTES = 16ull * 1024ull * 1024ull
+
+function ValidateSelfContainedBudget(byval max_bytes as ulongint = MAX_SELF_CONTAINED_BUDGET_BYTES) as integer
+  dim as string executable_path = exepath()
+
+  if len(executable_path) = 0 then
+    print "WARNING: unable to resolve executable path; skipping size budget check."
+    return FALSE
+  end if
+
+  dim as longint executable_size = filelen(executable_path)
+  if executable_size < 0 then
+    print "WARNING: unable to read executable size for " & executable_path & "; skipping size budget check."
+    return FALSE
+  end if
+
+  if culngint(executable_size) > max_bytes then
+    print "ERROR: self-contained artifact exceeds 16MB deployment limit."
+    print "       path: " & executable_path
+    print "       size: " & executable_size & " bytes"
+    print "      limit: " & max_bytes & " bytes"
+    return FALSE
+  end if
+
+  return TRUE
+end function
+
+if ValidateSelfContainedBudget() = FALSE then
+  end 1
+end if
+
 screenres 800, 600, 32
 screeninfo screen_width, screen_height, bits_per_pixel, bytes_per_pixel, _ 
            bytes_per_scanline, refresh_rate, driver_name 


### PR DESCRIPTION
### Motivation
- The emulator must be self-contained and enforce a 16MB maximum artifact size so deployed binaries meet the project deployment constraint.

### Description
- Added a `MAX_SELF_CONTAINED_BUDGET_BYTES` constant and a `ValidateSelfContainedBudget(...)` function to `main.bas` to resolve the running executable path and check its file size.
- The validation prints clear diagnostics when it cannot resolve the path or read the size, and prints an explicit error and terminates early when the artifact exceeds 16MB.
- The new startup guard is executed before the existing initialization (ROM loading and `screenres`) so oversized builds fail fast at runtime.
- File modified: `main.bas` (startup budget enforcement logic added).

### Testing
- Attempted to compile with `fbc -w all main.bas -x /tmp/main_budget_check_test` and the compile step failed in this environment because `fbc` is not installed (`command not found`).
- No other automated tests were run in this environment; runtime behavior of the new check was validated by static inspection of the injected logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a738a644a4832c9b464287963986bf)