### PR TITLE
Support sparse double-addressed memory in 6510 MEMORY_T

### DIFF
--- a/c64dvd-glsl-old.bas
+++ b/c64dvd-glsl-old.bas
@@ -89,6 +89,7 @@ type MEMORY_T
   declare sub      WriteUShort(byval adr as double, byval w16 as double)
   declare function Peek64(byval adr as double) as double
   declare sub      poke64(byval adr as double, byval v as double)
+  declare function NormalizeAddress(byval adr as double) as double
 #if 0
   const as ulongint mov(os_end,      &HFFFF) '------|
   const as ulongint mov(os_base,     &HE000) '  8 K | KERNAL ROM or RAM (adr 0 bit1=0 RAM bit1=1 ROM
@@ -117,6 +118,9 @@ type MEMORY_T
   as double   basic (00016383d) ' Basic
   as double   char  (00016383d) ' Font
   as double   col   (00001023d) ' color triples
+  as double   sparseAdr()
+  as ubyte    sparseVal()
+  as ulong    sparseCount
 end type
 
 enum ADR_MODES
@@ -341,6 +345,9 @@ destructor C64_T
 end destructor
 
 constructor MEMORY_T
+  redim sparseAdr(0)
+  redim sparseVal(0)
+  sparseCount = 0
   'Set default memory addresses
   mov(sys_offset,49152d)
   mov(fg_red, sys_offset add 2d):     mov(fg_grn, sys_offset add 3d)
@@ -484,20 +491,70 @@ destructor MEMORY_T
   dprint("MEMORY_T~")
 end destructor
 
+proc MEMORY_T.NormalizeAddress(byval adr as double) as double
+  if (adr <> adr) then
+    proc = 0d
+    exit proc
+  end if
+  if (abs(adr) > 1.7976931348623157d+308) then
+    proc = 0d
+    exit proc
+  end if
+  proc = adr
+end proc
+
 proc MEMORY_T.Peek64(byval adr as double) as double
-  select case adr 
-  case &HE000 to &HFFFF:mov(proc,kernal(adr-&HE000))
-  case &HA000 to &HBFFF:mov(proc,basic (adr-&HA000))
-  case &HD800 to &HDBFF:mov(proc,char  (adr-&HD800))
-  case &HD000 to &HD3FF
-    var mov(reg,logic_and(adr,&H003f))
-    if mov(reg, &H12) then mov(proc,0d) else mov(proc,&HFF)
-  case else : mov(proc,mem64(adr))
-  end select
+  adr = NormalizeAddress(adr)
+  if (adr = fix(adr)) andalso (adr >= 0d) andalso (adr <= ubound(mem64)) then
+    dim as ulong idx = culng(adr)
+    select case idx
+    case &HE000 to &HFFFF:mov(proc,kernal(idx-&HE000))
+    case &HA000 to &HBFFF:mov(proc,basic (idx-&HA000))
+    case &HD800 to &HDBFF:mov(proc,char  (idx-&HD800))
+    case &HD000 to &HD3FF
+      var mov(reg,logic_and(idx,&H003f))
+      if mov(reg, &H12) then mov(proc,0d) else mov(proc,&HFF)
+    case else : mov(proc,mem64(idx))
+    end select
+    exit proc
+  end if
+
+  if sparseCount > 0 then
+    for i as ulong = 0 to sparseCount-1
+      if sparseAdr(i) = adr then
+        proc = sparseVal(i)
+        exit proc
+      end if
+    next i
+  end if
+  proc = 0d
 end proc
 
 def MEMORY_T.poke64(byval adr as double,byval v as double)
-  mov(mem64(adr), v)
+  adr = NormalizeAddress(adr)
+  v = logic_and(v,255d)
+  if (adr = fix(adr)) andalso (adr >= 0d) andalso (adr <= ubound(mem64)) then
+    mov(mem64(culng(adr)), v)
+  else
+    if sparseCount > 0 then
+      for i as ulong = 0 to sparseCount-1
+        if sparseAdr(i) = adr then
+          sparseVal(i) = cubyte(v)
+          exit def
+        end if
+      next i
+    end if
+    if sparseCount = 0 then
+      redim sparseAdr(0)
+      redim sparseVal(0)
+    else
+      redim preserve sparseAdr(sparseCount)
+      redim preserve sparseVal(sparseCount)
+    end if
+    sparseAdr(sparseCount) = adr
+    sparseVal(sparseCount) = cubyte(v)
+    sparseCount += 1
+  end if
   if logic_and(adr geq 55296d,adr leq 56319d) then
     mov(adr subt, 55296d): mov(col(adr), v)
     mov(adr add, mem64(scr_ptr))


### PR DESCRIPTION
### Motivation
- The 6510 memory layer used double-precision addresses in several variants and needed a safe way to handle non-integer, negative or very large double addresses without indexing the fixed `mem64` array out-of-bounds.
- Add a sparse storage path so fractional or out-of-range addresses can be read/written without corrupting the dense RAM/ROM buffers.

### Description
- Extended `MEMORY_T` in `c64dvd-glsl-old.bas` with `sparseAdr()`, `sparseVal()`, and `sparseCount` to store non-dense (double) addresses and values, and initialized them in the `MEMORY_T` constructor.
- Added `NormalizeAddress()` to sanitize addresses (detect `NaN` and extremely large values) and return a stable numeric value for subsequent logic.
- Reworked `Peek64()` to call `NormalizeAddress()` and keep the original fast path for in-range integer addresses (ROM/RAM/char/col mappings), while falling back to a sparse lookup for non-integer or out-of-range addresses and returning `0` if unset.
- Reworked `poke64()` to sanitize and mask written values to a byte (`AND 255`), write into dense `mem64` when the normalized address is an in-range integer, or insert/update the sparse arrays (resizing them) for other double addresses, while preserving existing special side-effects (color/VRAM handling) for mapped ranges.

### Testing
- Verified file changes and working tree status with `git status --short`, which showed the updated file (`c64dvd-glsl-old.bas`).
- Checked presence of the FreeBASIC compiler with `command -v fbc` and found the toolchain is not installed in the container, so no compile was performed.
- Confirmed textual edits (added declarations, constructor initialization, `NormalizeAddress`, updated `Peek64`/`poke64`) via `git diff` and file inspection; no automated runtime tests were executed due to missing `fbc`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a739d38fa0832cb398f130eea73dd6)