### PR TITLE
Expose GPU capability registers and document extended VRAM addressing

### DIFF
--- a/chipset.bas
+++ b/chipset.bas
@@ -225,6 +225,11 @@ case sys_offset+&HB2 ' Render
   bload "vram/"+str(mem64(sys_offset+&HB4))+".bmp",image
   put (0,0),image, alpha	       
 case sys_offset+&HB3' Sets offset in video memory
+  ' VRAM offsets are stored as IEEE-754 doubles so they can represent:
+  '  * positive addresses up to 1.797693134862316e+308 x 8 bytes
+  '  * negative addresses down to -1.797693134862316e+308 x 8 bytes
+  '  * zero
+  ' This keeps compatibility with the extended GPU addressing model.
   mem64(sys_offset+&HB4)=v
 case sys_offset+&HB5 ' Anamation player
   poke64(sys_offset+&HAB,0) ' clear screen
@@ -447,4 +452,14 @@ case sys_offset+&HEE 'POV-Ray terninal
      sleep
      ScreenRes 1920,1080, 32, 0, GFX_FULLSCREEN 'OR GFX_ALPHA_PRIMITIVES: Cls
 	 poke64(sys_offset+&HBC,0) ' reset screen
+case sys_offset+&HF0 ' GPU clock in GHz (read-only capability register)
+  mem64(sys_offset+&HF0) = 17
+case sys_offset+&HF1 ' GPU bus width in bits (read-only capability register)
+  mem64(sys_offset+&HF1) = 512
+case sys_offset+&HF2 ' GPU max addressable VRAM bytes
+  mem64(sys_offset+&HF2) = 1.797693134862316e+308 * 8
+case sys_offset+&HF3 ' GPU compatibility bitfield: 1=VIC-II,2=SVGA,4=ECS,8=AGA(HAM8)
+  mem64(sys_offset+&HF3) = &H0F
+case sys_offset+&HF4 ' Copperlists color mode bits-per-pixel (ARGB8888)
+  mem64(sys_offset+&HF4) = 32
 case sys_offset+&HFF: system

--- a/memory.bi
+++ b/memory.bi
@@ -16,6 +16,13 @@ constructor SYSTEM_BUS_T
   ' SYS_OFFSET$ = (double)((int64)*(uint8*)4808108ll << ((int64)*(uint8*)4808108ll & 63ll));
   poke SYSTEM_TYPE,@sys_offset, peek(ubyte,@nibbles(&B1100)) shl peek(ubyte,@nibbles(&B1100))
 
+  ' Initialize GPU capability registers
+  poke SYSTEM_TYPE,@mem64(sys_offset+&HF0),17                            ' GPU clock (GHz)
+  poke SYSTEM_TYPE,@mem64(sys_offset+&HF1),512                           ' GPU bus width (bits)
+  poke SYSTEM_TYPE,@mem64(sys_offset+&HF2),1.797693134862316e+308 * 8    ' Max VRAM bytes
+  poke SYSTEM_TYPE,@mem64(sys_offset+&HF3),&H0F                          ' VIC-II/SVGA/ECS/AGA(HAM8)
+  poke SYSTEM_TYPE,@mem64(sys_offset+&HF4),32                            ' Copperlist ARGB8888
+
   ' initialize zero page and the stack
 
   ' This code block initializes the zero page, a block of memory at the beginning of the address


### PR DESCRIPTION
### Motivation
- Provide an in-memory, queryable representation of the requested GPU profile and capabilities so emulated clients and scripts can discover clock, bus width, max VRAM and color-mode details at runtime.
- Ensure the video-memory offset register semantics are clear and compatible with the extended IEEE‑754 based address model described in the spec.

### Description
- Initialize new GPU capability registers in the system bus constructor in `memory.bi`: `sys_offset + &HF0` (GPU clock GHz), `&HF1` (bus width bits), `&HF2` (max VRAM bytes), `&HF3` (compatibility bitfield) and `&HF4` (copperlist color bpp).
- Add chipset handlers in `chipset.bas` for the same `sys_offset + &HF*` registers so they can be read via the mapped I/O path at runtime.
- Document VRAM offset semantics in the `sys_offset + &HB3` handler comment to note that offsets are stored as IEEE‑754 doubles and support positive/negative/zero values across the extended range.

### Testing
- Ran `pytest -q tests/test_memory.py`, which passed (`2 passed`).
- Ran `pytest -q` for overall validation; this still reports unrelated codec lookup failures (6 failing tests referencing custom PETSCII/screencode codecs) that pre‑existed and are not affected by these GPU register changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73b939130832c80c99142557f9cff)