### PR TITLE
Add branch predictor timing model for x86 conditional branches

### DIFF
--- a/src/fb80486/386c.bas
+++ b/src/fb80486/386c.bas
@@ -14,6 +14,7 @@ Sub exec386(ByVal cycs As Integer)
         Dim As Integer oldcyc=Any 
         Dim As integer tempi=Any 
         Dim As integer trap =any
+        Dim As Integer branch_taken =Any
 
         cycles+=cycs 
         
@@ -676,123 +677,75 @@ Sub exec386(ByVal cycs As Integer)
                         		  Exit Select 
                         	case &h80  /'JO'/
                                 tempw=getword2f() 
-                                if (flags And V_FLAG) Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And V_FLAG), CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h81  /'JNO'/
                                 tempw=getword2f() 
-                                if (flags And V_FLAG)=0 Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And V_FLAG)=0, CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h82  /'JB'/
                                 tempw=getword2f() 
-                                if (flags And C_FLAG) Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And C_FLAG), CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h83  /'JNB'/
                                 tempw=getword2f() 
-                                if (flags And C_FLAG)=0 Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And C_FLAG)=0, CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h84  /'JE'/
                                 tempw=getword2f() 
-                                if (flags And Z_FLAG) Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And Z_FLAG), CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h85  /'JNE'/
                                 tempw=getword2f() 
-                                if (flags And Z_FLAG)=0 Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And Z_FLAG)=0, CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h86  /'JBE'/
                                 tempw=getword2f() 
-                                if (flags And (C_FLAG Or Z_FLAG)) Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And (C_FLAG Or Z_FLAG)), CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h87  /'JNBE'/
                                 tempw=getword2f() 
-                                if (flags And (C_FLAG Or Z_FLAG))=0 Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And (C_FLAG Or Z_FLAG))=0, CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h88  /'JS'/
                                 tempw=getword2f() 
-                                if (flags And N_FLAG) Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And N_FLAG), CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h89  /'JNS'/
                                 tempw=getword2f() 
-                                if (flags And N_FLAG)=0 Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And N_FLAG)=0, CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h8A  /'JP'/
                                 tempw=getword2f() 
-                                if (flags And P_FLAG) Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And P_FLAG), CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h8B  /'JNP'/
                                 tempw=getword2f() 
-                                if (flags And P_FLAG)=0 Then 
-                                         pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((flags And P_FLAG)=0, CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h8C  /'JL'/
                                 tempw=getword2f() 
                                 temp=IIf((flags And N_FLAG),1,0) 
                                 temp2=IIf((flags And V_FLAG),1,0 )
-                                if (temp<>temp2) Then 
-                                          pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((temp<>temp2), CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h8D  /'JNL'/
                                 tempw=getword2f() 
                                 temp=IIf((flags And N_FLAG),1,0) 
                                 temp2=IIf((flags And V_FLAG),1,0 )
-                                if (temp=temp2) Then 
-                                          pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR((temp=temp2), CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h8E  /'JLE'/
                                 tempw=getword2f() 
                                 temp=IIf((flags And N_FLAG),1,0 )
                                 temp2=IIf((flags And V_FLAG),1,0 )
-                                if ((flags And Z_FLAG)<>0) Or (temp<>temp2) Then 
-                                          pc+=CShort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR(((flags And Z_FLAG)<>0) Or (temp<>temp2), CShort(tempw), oldpc) 
                                 Exit Select 
                         	case &h8F  /'JNLE'/
                                 tempw=getword2f() 
                                 temp=IIf((flags And N_FLAG),1,0 )
                                 temp2=IIf((flags And V_FLAG),1,0 )
-                                if ( ((flags And Z_FLAG)<>0) Or (temp<>temp2) )=0 Then 
-                                          pc+=cshort(tempw): cycles-=timing_bt  
-                                EndIf
-                                cycles -= timing_bnt 
+                                APPLY_BRANCH_WITH_PREDICTOR(( ((flags And Z_FLAG)<>0) Or (temp<>temp2) )=0, cshort(tempw), oldpc) 
                                 Exit Select 
                         	case &h90  /'SETO'/
                                 fetchea2() : if abrt then exit Select
@@ -3374,123 +3327,75 @@ Sub exec386(ByVal cycs As Integer)
                         Exit Select 
                 	case &h70, &h170, &h270, &h370  /'JO'/
                         offset=cbyte(getbytef())
-                        if (flags And V_FLAG) Then 
-                                 pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And V_FLAG), offset, oldpc) 
                         Exit Select 
                 	case &h71, &h171, &h271, &h371  /'JNO'/
                         offset=cbyte(getbytef())
-                        if (flags And V_FLAG)=0 Then 
-                                 pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And V_FLAG)=0, offset, oldpc) 
                         Exit Select 
                 	case &h72, &h172, &h272, &h372  /'JB'/
                         offset=cbyte(getbytef()) 
-                        if (flags And C_FLAG) Then 
-                                 pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And C_FLAG), offset, oldpc) 
                         Exit Select 
                 	case &h73, &h173, &h273, &h373  /'JNB'/
                         offset=cbyte(getbytef()) 
-                        if (flags And C_FLAG)=0 Then 
-                                 pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And C_FLAG)=0, offset, oldpc) 
                         Exit Select 
                 	case &h74, &h174, &h274, &h374  /'JZ'/
                         offset=cbyte(getbytef()) 
-                        if (flags And Z_FLAG) Then 
-                                 pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And Z_FLAG), offset, oldpc) 
                         Exit Select 
                 	case &h75, &h175, &h275, &h375  /'JNZ'/
                         offset=cbyte(getbytef()) 
-                        if (flags And Z_FLAG)=0 Then 
-                                 pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And Z_FLAG)=0, offset, oldpc) 
                         Exit Select 
                 	case &h76, &h176, &h276, &h376  /'JBE'/
                         offset=cbyte(getbytef()) 
-                        if (flags And (C_FLAG Or Z_FLAG)) Then 
-                                 pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And (C_FLAG Or Z_FLAG)), offset, oldpc) 
                         Exit Select 
                 	case &h77, &h177, &h277, &h377  /'JNBE'/
                         offset=cbyte(getbytef()) 
-                        if (flags And (C_FLAG Or Z_FLAG))=0 Then 
-                                 pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And (C_FLAG Or Z_FLAG))=0, offset, oldpc) 
                         Exit Select 
                 	case &h78, &h178, &h278, &h378  /'JS'/
                         offset=cbyte(getbytef()) 
-                        if (flags And N_FLAG) Then 
-                                  pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And N_FLAG), offset, oldpc) 
                         Exit Select 
                 	case &h79, &h179, &h279, &h379  /'JNS'/
                         offset=cbyte(getbytef()) 
-                        if (flags And N_FLAG)=0 Then 
-                                  pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And N_FLAG)=0, offset, oldpc) 
                         Exit Select 
                 	case &h7A, &h17A, &h27A, &h37A  /'JP'/
                         offset=cbyte(getbytef()) 
-                        if (flags And P_FLAG) Then 
-                                  pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And P_FLAG), offset, oldpc) 
                         Exit Select 
                 	case &h7B, &h17B, &h27B, &h37B  /'JNP'/
                         offset=cbyte(getbytef()) 
-                        if (flags And P_FLAG)=0 Then 
-                                  pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And P_FLAG)=0, offset, oldpc) 
                         Exit Select 
                 	case &h7C, &h17C, &h27C, &h37C  /'JL'/
                         offset=cbyte(getbytef()) 
                         temp=iif((flags And N_FLAG),1,0 )
                         temp2=iif((flags And V_FLAG),1,0 )
-                        if (temp<>temp2) Then 
-                                  pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((temp<>temp2), offset, oldpc) 
                         Exit Select 
                 	case &h7D, &h17D, &h27D, &h37D  /'JNL'/
                         offset=cbyte(getbytef()) 
                         temp=iif((flags And N_FLAG),1,0 )
                         temp2=iif((flags And V_FLAG),1,0 )
-                        if (temp=temp2) Then 
-                                  pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((temp=temp2), offset, oldpc) 
                         Exit Select 
                 	case &h7E, &h17E, &h27E, &h37E  /'JLE'/
                         offset=cbyte(getbytef()) 
                         temp=iif((flags And N_FLAG),1,0 )
                         temp2=iif((flags And V_FLAG),1,0 )
-                        if (flags And Z_FLAG)  Or  (temp<>temp2) Then 
-                                  pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR((flags And Z_FLAG)  Or  (temp<>temp2), offset, oldpc) 
                         Exit Select 
                 	case &h7F, &h17F, &h27F, &h37F  /'JNLE'/
                         offset=cbyte(getbytef()) 
                         temp=IIf((flags And N_FLAG),1,0 )
                         temp2=iif((flags And V_FLAG),1,0 )
-                        if ( ((flags And Z_FLAG)<>0) Or (temp<>temp2) )=0 Then 
-                                  pc += offset: cycles -= timing_bt  
-                        EndIf
-                        cycles -= timing_bnt 
+                        APPLY_BRANCH_WITH_PREDICTOR(( ((flags And Z_FLAG)<>0) Or (temp<>temp2) )=0, offset, oldpc) 
                         Exit Select 
                 	case &h80, &h180, &h280, &h380 ,_
 		                 &h82, &h182, &h282, &h382 

--- a/src/fb80486/ibm.bi
+++ b/src/fb80486/ibm.bi
@@ -13,6 +13,16 @@ static shared As Integer timing_mr, timing_mrl
 static shared As Integer timing_rm, timing_rml
 static shared As Integer timing_mm, timing_mml
 static shared As Integer timing_bt, timing_bnt
+static shared As Integer timing_bm
+
+static shared As UByte branch_predictor(0 To 255)
+static shared As ULong branch_predictions
+static shared As ULong branch_mispredictions
+
+Declare Sub branch_predictor_reset()
+Declare Sub branch_predictor_update(ByVal branch_pc As ULong, ByVal branch_taken As Integer)
+
+#Define APPLY_BRANCH_WITH_PREDICTOR(_cond,_disp,_pc) branch_taken=IIf((_cond),1,0):If branch_taken Then pc+=(_disp):cycles-=timing_bt:EndIf:cycles-=timing_bnt:branch_predictor_update((_pc),branch_taken)
 
 ' Program Counter
 static shared As ULong pc

--- a/src/fb80486/x86.bas
+++ b/src/fb80486/x86.bas
@@ -78,6 +78,33 @@ Sub cpu_CPUID()
 End sub
 
 
+Sub branch_predictor_reset()
+        Dim As Integer i
+        For i = 0 To 255
+                branch_predictor(i) = 1 'weakly not-taken
+        Next
+        branch_predictions = 0
+        branch_mispredictions = 0
+End Sub
+
+Sub branch_predictor_update(ByVal branch_pc As ULong, ByVal branch_taken As Integer)
+        Dim As Integer idx = (branch_pc Shr 1) And &hFF
+        Dim As Integer predicted_taken = IIf((branch_predictor(idx) >= 2),1,0)
+
+        branch_predictions += 1
+        If predicted_taken <> branch_taken Then
+                branch_mispredictions += 1
+                cycles -= timing_bm
+        End If
+
+        If branch_taken Then
+                If branch_predictor(idx) < 3 Then branch_predictor(idx) += 1
+        Else
+                If branch_predictor(idx) > 0 Then branch_predictor(idx) -= 1
+        End If
+End Sub
+
+
 
 ' inicializa CPU
 Sub resetx86(reset_cpu As Integer) 
@@ -103,6 +130,9 @@ Sub resetx86(reset_cpu As Integer)
 		rammask=&hFFFFFFFF 
 		flags=2 
 		
+		branch_predictor_reset()
+
+		
 		initmmucache() ' CPU cache
 		resetreadlookup() ' look ahead CPU
 		
@@ -114,7 +144,10 @@ Sub resetx86(reset_cpu As Integer)
 		ESP=0 
 		mmu_perm=4 		
 		
-		' esto es del PREFETCHCLEAR que estaba en el X86.C pero ¿¿¿SOLO se emplea en el Reset????
+        branch_predictor_reset()
+			timing_bm  = 3 'branch mispredict penalty
+			branch_predictor_reset()
+		' esto es del PREFETCHCLEAR que estaba en el X86.C pero Â¿Â¿Â¿SOLO se emplea en el Reset????
         'prefetchpc=pc
         'prefetchw=0
         'memcycs=cycdiff-cycles


### PR DESCRIPTION
### Motivation

- Introduce a simple branch predictor timing model so conditional jumps in the x86 emulator account for prediction state and a misprediction penalty, improving timing fidelity for pipeline/branch-sensitive workloads.

### Description

- Add predictor state, counters and a mispredict penalty to `src/fb80486/ibm.bi` including `timing_bm`, `branch_predictor(0 To 255)`, `branch_predictions`, `branch_mispredictions`, and the `APPLY_BRANCH_WITH_PREDICTOR` macro.
- Implement `branch_predictor_reset()` and `branch_predictor_update()` in `src/fb80486/x86.bas`, with a 2-bit saturating update and application of `timing_bm` on misprediction, and hook predictor reset into CPU init/reset paths.
- Replace direct `Jcc` taken/not-taken handling in `src/fb80486/386c.bas` with the `APPLY_BRANCH_WITH_PREDICTOR` macro for both short and near branches so prediction state and penalty are applied uniformly.
- Add a local `branch_taken` variable to `exec386()` and initialize `timing_bm` during CPU timing setup to provide a default misprediction penalty.

### Testing

- Verified presence and usage with repository searches like `rg` for `APPLY_BRANCH_WITH_PREDICTOR`, `timing_bm`, and `branch_predictor_update`, which showed the macro and helpers are declared and used in the updated files.
- Ran `git diff --check` which reported trailing-whitespace warnings in modified lines (these whitespace issues were noted by the check). 
- Attempted to run the FreeBASIC compiler (`command -v fbc`) but it is not available in this environment so no compile-time or runtime validation was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a73e543080832c81ce0bd597f069d9)