### PR TITLE
Add 2-bit branch predictor hooks to 6510 emulation branch operations

### DIFF
--- a/E6510CPU.bas
+++ b/E6510CPU.bas
@@ -127,6 +127,46 @@ type MULTI
  end union   
 end type
 
+' 2-bit dynamic branch predictor (00 strong NT, 01 weak NT, 10 weak T, 11 strong T)
+const BRANCH_PREDICTOR_SIZE = 256
+static shared as ubyte branchPredictorState(BRANCH_PREDICTOR_SIZE - 1)
+static shared as ulongint branchPredictorPredictions, branchPredictorHits, branchPredictorMisses
+
+function BranchPredictorIndex(byval pc as ushort) as ubyte
+  return pc and (BRANCH_PREDICTOR_SIZE - 1)
+end function
+
+function BranchPredictorPredictTaken(byval pc as ushort) as ubyte
+  dim as ubyte idx = BranchPredictorIndex(pc)
+  return iif(branchPredictorState(idx) >= 2, 1, 0)
+end function
+
+sub BranchPredictorUpdate(byval pc as ushort, byval taken as ubyte)
+  dim as ubyte idx = BranchPredictorIndex(pc)
+  dim as ubyte predictedTaken = BranchPredictorPredictTaken(pc)
+  branchPredictorPredictions += 1
+  if predictedTaken = taken then
+    branchPredictorHits += 1
+  else
+    branchPredictorMisses += 1
+  end if
+  if taken then
+    if branchPredictorState(idx) < 3 then branchPredictorState(idx) += 1
+  else
+    if branchPredictorState(idx) > 0 then branchPredictorState(idx) -= 1
+  end if
+end sub
+
+sub ApplyPredictedBranch(byval Cpu as CPU6510_T, byval taken as ubyte)
+  dim as MULTI v
+  dim as ushort branchPc = Cpu->pc
+  v.u16 = branchPc
+  v.s16-=1
+  v.s16+=Cpu->mem->ReadByte(Cpu->Code.op.u16)+1
+  BranchPredictorUpdate(branchPc, taken)
+  if taken then Cpu->pc=v.u16
+end sub
+
 type OPCODE
   as ulongint    code
   as zstring * 4 nam
@@ -822,33 +862,15 @@ sub INS_ASLA(byval Cpu as CPU6510_T) ' ac
 end sub
 
 sub INS_BCC(byval Cpu as CPU6510_T)
-  if Cpu->F.c=0 then
-    dim as MULTI v
-    v.u16 =Cpu->pc
-    v.s16-=1
-    v.s16+=Cpu->mem->ReadByte(Cpu->Code.op.u16)+1
-    Cpu->pc=v.u16
-  end if
+  ApplyPredictedBranch(Cpu, iif(Cpu->F.c=0,1,0))
 end sub
 
 sub INS_BCS(byval Cpu as CPU6510_T)
-  if Cpu->F.c then
-    dim as MULTI v
-    v.u16 =Cpu->pc
-    v.s16-=1
-    v.s16+=Cpu->mem->ReadByte(Cpu->Code.op.u16)+1
-    Cpu->pc=v.u16
-  end if
+  ApplyPredictedBranch(Cpu, iif(Cpu->F.c<>0,1,0))
 end sub
 
 sub INS_BEQ(byval Cpu as CPU6510_T)
-  if Cpu->F.z=1 then
-    dim as MULTI v
-    v.u16 =Cpu->pc
-    v.s16-=1
-    v.s16+=Cpu->mem->ReadByte(Cpu->Code.op.u16)+1
-    Cpu->pc=v.u16
-  end if
+  ApplyPredictedBranch(Cpu, iif(Cpu->F.z=1,1,0))
 end sub
 
 sub INS_BIT(byval Cpu as CPU6510_T)
@@ -860,33 +882,15 @@ sub INS_BIT(byval Cpu as CPU6510_T)
 end sub
 
 sub INS_BMI(byval Cpu as CPU6510_T)
-  if Cpu->F.n then
-    dim as MULTI v
-    v.u16 =Cpu->pc
-    v.s16-=1
-    v.s16+=Cpu->mem->ReadByte(Cpu->Code.op.u16)+1
-    Cpu->pc=v.u16
-  end if
+  ApplyPredictedBranch(Cpu, iif(Cpu->F.n<>0,1,0))
 end sub
 
 sub INS_BNE(byval Cpu as CPU6510_T)
-  if Cpu->F.z=0 then
-    dim as MULTI v
-    v.u16 =Cpu->pc
-    v.s16-=1
-    v.s16+=Cpu->mem->ReadByte(Cpu->Code.op.u16)+1
-    Cpu->pc=v.u16
-  end if
+  ApplyPredictedBranch(Cpu, iif(Cpu->F.z=0,1,0))
 end sub
 
 sub INS_BPL(byval Cpu as CPU6510_T)
-  if Cpu->F.n=0 then
-    dim as MULTI v
-    v.u16 =Cpu->pc
-    v.s16-=1
-    v.s16+=Cpu->mem->ReadByte(Cpu->Code.op.u16)+1
-    Cpu->pc=v.u16
-  end if
+  ApplyPredictedBranch(Cpu, iif(Cpu->F.n=0,1,0))
 end sub
 
 sub INS_BRK(byval Cpu as CPU6510_T)
@@ -900,23 +904,11 @@ sub INS_BRK(byval Cpu as CPU6510_T)
 end sub
 
 sub INS_BVC(byval Cpu as CPU6510_T)
-  if Cpu->F.v=0 then
-    dim as MULTI v
-    v.u16 =Cpu->pc
-    v.s16-=1
-    v.s16+=Cpu->mem->ReadByte(Cpu->Code.op.u16)+1
-    Cpu->pc=v.u16
-  end if
+  ApplyPredictedBranch(Cpu, iif(Cpu->F.v=0,1,0))
 end sub
 
 sub INS_BVS(byval Cpu as CPU6510_T)
-  if Cpu->F.v then
-    dim as MULTI v
-    v.u16 =Cpu->pc
-    v.s16-=1
-    v.s16+=Cpu->mem->ReadByte(Cpu->Code.op.u16)+1
-    Cpu->pc=v.u16
-  end if
+  ApplyPredictedBranch(Cpu, iif(Cpu->F.v<>0,1,0))
 end sub
 
 sub INS_CLC(byval Cpu as CPU6510_T)

--- a/c64dvd-glsl.bas
+++ b/c64dvd-glsl.bas
@@ -2635,6 +2635,36 @@ type MULTI
 end type
 
 static shared as MULTI v,o
+
+' 2-bit dynamic branch predictor (00 strong NT, 01 weak NT, 10 weak T, 11 strong T)
+const BRANCH_PREDICTOR_SIZE = 256
+static shared as ubyte branchPredictorState(BRANCH_PREDICTOR_SIZE - 1)
+static shared as ulongint branchPredictorPredictions, branchPredictorHits, branchPredictorMisses
+
+def BranchPredictorIndex(byval pc as ushort) as ubyte
+  proc = pc and (BRANCH_PREDICTOR_SIZE - 1)
+end def
+
+def BranchPredictorPredictTaken(byval pc as ushort) as ubyte
+  var idx = BranchPredictorIndex(pc)
+  proc = iif(branchPredictorState(idx) >= 2, peek(ubyte,@nibbles(&B0001)), peek(ubyte,@nibbles(&B0000)))
+end def
+
+def BranchPredictorUpdate(byval pc as ushort, byval taken as ubyte)
+  var idx = BranchPredictorIndex(pc)
+  var predictedTaken = BranchPredictorPredictTaken(pc)
+  branchPredictorPredictions += peek(ubyte,@nibbles(&B0001))
+  if predictedTaken = taken then
+    branchPredictorHits += peek(ubyte,@nibbles(&B0001))
+  else
+    branchPredictorMisses += peek(ubyte,@nibbles(&B0001))
+  end if
+  if taken then
+    if branchPredictorState(idx) < 3 then branchPredictorState(idx) += peek(ubyte,@nibbles(&B0001))
+  else
+    if branchPredictorState(idx) > 0 then branchPredictorState(idx) -= peek(ubyte,@nibbles(&B0001))
+  end if
+end def
    
 type OPCODE
   as uint64      code
@@ -3319,10 +3349,12 @@ end def
 ' - predicate = 1: branch target updates architectural state (PC)
 ' - predicate = 0: target is calculated but architectural state is not modified
 def ApplyPredicatedBranch(byval Cpu as CPU6510_T, byval predicate as ubyte)
-  static as ushort candidatePc
-  candidatePc = Cpu->pc
+  static as ushort candidatePc, branchPc
+  branchPc = Cpu->pc
+  candidatePc = branchPc
   candidatePc -= peek(ubyte,@nibbles(&B0001))
   candidatePc += Cpu->mem->ReadByte(Cpu->Code.op.u16) + peek(ubyte,@nibbles(&B0001))
+  BranchPredictorUpdate(branchPc, predicate)
   if predicate then Cpu->pc = candidatePc
 end def
 


### PR DESCRIPTION
### Motivation
- Add a lightweight 2-bit dynamic branch predictor model to the 6510 CPU emulation so conditional branches can be measured and tracked without changing semantic behavior. 
- Centralize branch target calculation and predictor accounting so all conditional branch instructions update predictor state consistently.

### Description
- Introduce a 2-bit saturating counter predictor with a 256-entry table and global counters (`branchPredictorState`, `branchPredictorPredictions`, `branchPredictorHits`, `branchPredictorMisses`) implemented in `c64dvd-glsl.bas` and in `E6510CPU.bas`.
- Add helper primitives: `BranchPredictorIndex`, `BranchPredictorPredictTaken`, and `BranchPredictorUpdate` in both files to index, predict, and update the table.
- Update predicated branch helper so branch outcomes call the predictor update routine and preserve original PC update semantics (in `c64dvd-glsl.bas` the `ApplyPredicatedBranch` helper now updates predictor state; in `E6510CPU.bas` a new `ApplyPredictedBranch` sub was added that does the same).
- Refactor conditional branch instruction handlers (`BCC`, `BCS`, `BEQ`, `BMI`, `BNE`, `BPL`, `BVC`, `BVS`) to call the centralized branch helper so prediction accounting is performed uniformly while maintaining original branch behavior.

### Testing
- Verified new symbols and call sites with `rg -n "BranchPredictor" c64dvd-glsl.bas E6510CPU.bas`, which found the inserted functions and update calls (succeeded).
- Inspected diffs with `git diff --stat` and file contents with `nl`/`sed` to confirm the expected changes were applied (succeeded).
- Attempted to run `fbc --version` to perform a compile-time validation but `fbc` is not installed in this environment (failed); no FreeBASIC binary build was executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74224d5b4832c89f08328caf905df)