### PR TITLE
Add firmware/UEFI BIOS size capability registers to emulated system bus

### DIFF
--- a/c64dvd-glsl.bas
+++ b/c64dvd-glsl.bas
@@ -382,6 +382,16 @@ faster than accessing it directly from main memory. Prefetching can be done with
 #define SCR_PTR_ADR3                     &HC12B  ' (49451)
 #define LD_PC_STATUS_PTR                 &HC12C
 
+' Firmware/UEFI capability registers (sizes in megabytes unless noted)
+#define FW_BIOS_LEGACY_MIN_MB_PTR        &HC130  ' (49456) Legacy BIOS lower-bound (historical)
+#define FW_BIOS_LEGACY_MAX_MB_PTR        &HC131  ' (49457) Legacy BIOS upper-bound (historical)
+#define FW_UEFI_MODERN_MIN_MB_PTR        &HC132  ' (49458) Modern UEFI lower-bound
+#define FW_UEFI_MODERN_COMMON_MB_PTR     &HC133  ' (49459) Modern UEFI common size
+#define FW_UEFI_MODERN_MAX_MB_PTR        &HC134  ' (49460) Modern UEFI upper-bound observed
+#define FW_UEFI_COMMON_KB_PTR            &HC135  ' (49461) Modern UEFI common size in KiB
+#define FW_STORAGE_GPT_MAX_ZB_PTR        &HC136  ' (49462) GPT theoretical maximum addressable storage in ZB
+#define FW_STORAGE_IS_SPI_FLASH_PTR      &HC137  ' (49463) 1 = motherboard SPI flash device
+
 ' Character generator ROM
 #define CHAR_GEN_ROM_START               &HD000
 #define CHAR_GEN_ROM_END                 &HDFFF

--- a/memory.bi
+++ b/memory.bi
@@ -23,6 +23,17 @@ constructor SYSTEM_BUS_T
   poke SYSTEM_TYPE,@mem64(sys_offset+&HF3),&H0F                          ' VIC-II/SVGA/ECS/AGA(HAM8)
   poke SYSTEM_TYPE,@mem64(sys_offset+&HF4),32                            ' Copperlist ARGB8888
 
+  ' Initialize firmware capability registers
+  ' Sizes are kept in megabytes/kibibytes to mirror real SPI flash ROM parts.
+  poke SYSTEM_TYPE,@mem64(FW_BIOS_LEGACY_MIN_MB_PTR),4                   ' Older boards often used 4MB ROMs
+  poke SYSTEM_TYPE,@mem64(FW_BIOS_LEGACY_MAX_MB_PTR),8                   ' Older boards often used 8MB ROMs
+  poke SYSTEM_TYPE,@mem64(FW_UEFI_MODERN_MIN_MB_PTR),8                   ' Modern UEFI minimum commonly seen
+  poke SYSTEM_TYPE,@mem64(FW_UEFI_MODERN_COMMON_MB_PTR),32               ' 32MB (32768 KiB) common on feature-rich boards
+  poke SYSTEM_TYPE,@mem64(FW_UEFI_MODERN_MAX_MB_PTR),64                  ' 64MB boards emerging for larger firmware images
+  poke SYSTEM_TYPE,@mem64(FW_UEFI_COMMON_KB_PTR),32768                   ' 32MB in KiB
+  poke SYSTEM_TYPE,@mem64(FW_STORAGE_GPT_MAX_ZB_PTR),9.4                 ' GPT theoretical addressable storage limit
+  poke SYSTEM_TYPE,@mem64(FW_STORAGE_IS_SPI_FLASH_PTR),1                 ' 1 = SPI flash device on motherboard
+
   ' initialize zero page and the stack
 
   ' This code block initializes the zero page, a block of memory at the beginning of the address


### PR DESCRIPTION
### Motivation
- Expose firmware size and storage metadata to the emulator so guest code and tools can query typical BIOS/UEFI flash sizes and storage characteristics (legacy vs modern firmware, KiB value, GPT theoretical limit, SPI flash presence). 

### Description
- Add firmware capability register constants in `c64dvd-glsl.bas` (`FW_BIOS_LEGACY_MIN_MB_PTR`..`FW_STORAGE_IS_SPI_FLASH_PTR`) mapped into the $C130–$C137 register range. 
- Initialize those registers in the `SYSTEM_BUS_T` constructor in `memory.bi` with representative values (legacy 4–8 MB, modern 8/32/64 MB, `32768` KiB for 32 MB, GPT 9.4 ZB reference, and SPI flash flag = `1`). 
- Files modified: `c64dvd-glsl.bas`, `memory.bi`.

### Testing
- Ran `pytest -q`, which produced test failures in unrelated codec registration tests (6 failures regarding missing petscii/screencode encodings) and therefore are not caused by these changes. 
- Compiled `tests/test_memory.py` with `python -m py_compile` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a747640b7c832c97c5e0a385df7067)