### PR TITLE
Add modern UEFI firmware flash-size support to FB80486 emulator

### DIFF
--- a/c64dvd-glsl.bas
+++ b/c64dvd-glsl.bas
@@ -50,6 +50,21 @@ faster than accessing it directly from main memory. Prefetching can be done with
    #DEFINE SYSTEM_TYPE DOUBLE
 #ENDIF
 
+' UEFI/SPI firmware flash sizing presets (modern boards)
+#define UEFI_FLASH_MB_LEGACY_MIN          8
+#define UEFI_FLASH_MB_LEGACY_MAX          16
+#define UEFI_FLASH_MB_MAINSTREAM          32
+#define UEFI_FLASH_MB_HIGH_END            64
+#define UEFI_FLASH_MB_RECOMMENDED_DEFAULT UEFI_FLASH_MB_MAINSTREAM
+
+Function get_uefi_flash_size_category(ByVal flash_size_mb As Integer) As String
+  If flash_size_mb >= UEFI_FLASH_MB_HIGH_END Then Return "modern-high-end"
+  If flash_size_mb >= UEFI_FLASH_MB_MAINSTREAM Then Return "mainstream-modern"
+  If flash_size_mb >= UEFI_FLASH_MB_LEGACY_MIN Then Return "budget-legacy"
+  Return "legacy-bios-era"
+End Function
+
+
 ' declare def poke64(byval adr as SYSTEM_TYPE, byval v as SYSTEM_TYPE)
 
 ' Zeropage addressing (0-255)

--- a/src/fb80486/_80486_emu.bas
+++ b/src/fb80486/_80486_emu.bas
@@ -46,7 +46,9 @@ Const VRAM_TOTAL =((VRAM_SIZE*1024*1024)-1)
 
 ' memoria
 static shared As UByte rambuf(0 To RAM_TOTAL) 
-static shared As UByte rombuf(0 To &h1FFFF) 
+Const FIRMWARE_FLASH_SIZE_MB = 64
+Const FIRMWARE_FLASH_SIZE_BYTES =(FIRMWARE_FLASH_SIZE_MB*1024*1024)
+static shared As UByte rombuf(0 To FIRMWARE_FLASH_SIZE_BYTES-1) 
 static shared As UByte vrambuf(0 To VRAM_TOTAL) 
 static shared As UByte vrombuf(0 To &h7FFF) 
 'static shared As UByte rambiosbuf(&h10000) ' inventado por mi
@@ -135,6 +137,7 @@ loadbinary &h0000, "video\ET4K_W32.bin", vrom ' con 2mb de VRAM : esta permite l
 'loadbinary &h0000, "bios\ami486.bin", rom 
 
 init_PC("ali1429g") 
+firmware_set_flash_size_mb(FIRMWARE_FLASH_SIZE_MB)
 loadbinary &h0000, "bios\ali1429g.bin", rom 
 
 'loadbinary &h0000, "bios\test.bin", rom 

--- a/src/fb80486/ibm.bi
+++ b/src/fb80486/ibm.bi
@@ -67,6 +67,8 @@ static shared As UShort zero=0
 
 
 static shared As Integer shadowbios ,shadowbios_write, grabar_bios, modo_bios
+static shared As Integer firmware_flash_size_mb
+static shared As ULong firmware_flash_size_bytes
 static shared As ULong pccache
 static shared As UShort flags,eflags
 static shared As Ulong oldds',olddslimit,olddslimitw
@@ -75,6 +77,9 @@ static shared As Integer cpl_override
 
 
 static shared As Integer readflash ' Used by the IDE
+
+Declare Function firmware_recommended_flash_size_mb(ByVal motherboard_tier As String) As Integer
+Declare Sub firmware_set_flash_size_mb(ByVal size_mb As Integer)
 
 ' port variables
 static shared puertosb(0 To &hFFFF) as UByte

--- a/src/fb80486/mem.bas
+++ b/src/fb80486/mem.bas
@@ -9,6 +9,11 @@ static shared As Integer cache=4 ' en la rutina "mem_updatecache" 4=256k, el max
 static shared As Integer memwaitstate
 static shared As ULong biosmask=&hFFFF ' BIOS de 64k
 static shared As Integer cachesize=256
+
+Const FIRMWARE_FLASH_LEGACY_8_MB = 8
+Const FIRMWARE_FLASH_LEGACY_16_MB = 16
+Const FIRMWARE_FLASH_MAINSTREAM_32_MB = 32
+Const FIRMWARE_FLASH_HIGH_END_64_MB = 64
 'static shared as UByte romext(32768)
 static shared As ULong mmucache(0 To &hFFFFF)
 static shared As Integer mmucaches(0 To 53)
@@ -22,6 +27,31 @@ static Shared as ULong mem_logical_addr
 
 Declare Sub addwritelookup(virt As ULong , phys As ULong ) 
 Declare Sub addreadlookup (virt As ULong , phys As ULong )
+
+Function firmware_recommended_flash_size_mb(ByVal motherboard_tier As String) As Integer
+    Dim tier_lc As String = LCase(Trim(motherboard_tier))
+
+    If tier_lc = "premium" Or tier_lc = "enthusiast" Or tier_lc = "high-end" Then
+        Return FIRMWARE_FLASH_HIGH_END_64_MB
+    EndIf
+    If tier_lc = "mainstream" Or tier_lc = "midrange" Then
+        Return FIRMWARE_FLASH_MAINSTREAM_32_MB
+    EndIf
+    If tier_lc = "legacy" Or tier_lc = "budget" Then
+        Return FIRMWARE_FLASH_LEGACY_16_MB
+    EndIf
+
+    Return FIRMWARE_FLASH_MAINSTREAM_32_MB
+End Function
+
+Sub firmware_set_flash_size_mb(ByVal size_mb As Integer)
+    If size_mb < 1 Then size_mb = 1
+    If size_mb > FIRMWARE_FLASH_HIGH_END_64_MB Then size_mb = FIRMWARE_FLASH_HIGH_END_64_MB
+
+    firmware_flash_size_mb = size_mb
+    firmware_flash_size_bytes = Culng(size_mb) * 1024UL * 1024UL
+    biosmask = firmware_flash_size_bytes - 1UL
+End Sub
 
 
 


### PR DESCRIPTION
### Motivation

- Provide explicit support for modern UEFI/SPI firmware sizes (32MB/64MB) so the emulator can allocate and map larger BIOS/firmware images and reflect realistic motherboard tiers (legacy, mainstream, high-end).

### Description

- Add UEFI firmware sizing presets and a helper in `c64dvd-glsl.bas` (`UEFI_FLASH_*` constants and `get_uefi_flash_size_category`) to classify firmware chip sizes. 
- Extend the emulator shared state in `src/fb80486/ibm.bi` with `firmware_flash_size_mb` and `firmware_flash_size_bytes` and declare the firmware API (`firmware_recommended_flash_size_mb`, `firmware_set_flash_size_mb`).
- Implement firmware sizing logic in `src/fb80486/mem.bas` including `firmware_recommended_flash_size_mb()` and `firmware_set_flash_size_mb()` that compute `firmware_flash_size_bytes` and update `biosmask` accordingly, and add constants for common size thresholds (8/16/32/64 MB).
- Update bootstrap in `src/fb80486/_80486_emu.bas` to allocate the ROM buffer sized for a 64MB default (`Const FIRMWARE_FLASH_SIZE_MB = 64`) and call `firmware_set_flash_size_mb(FIRMWARE_FLASH_SIZE_MB)` before loading the BIOS image so memory reads/writes use the new `biosmask`.

### Testing

- Applied and verified patches and file updates using automated patch application; file diffs confirm changes to `c64dvd-glsl.bas`, `src/fb80486/ibm.bi`, `src/fb80486/mem.bas`, and `src/fb80486/_80486_emu.bas`.
- Performed symbol/source checks with `rg` to confirm new constants and function names (`UEFI_FLASH_*`, `firmware_set_flash_size_mb`, `biosmask`) are present and referenced.
- Attempted to run the FreeBASIC compiler (`fbc --version`) for a build verification but the compiler is not available in this environment, so runtime compilation/execution tests were not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74959b2e4832c9eb46b2a72c99ded)